### PR TITLE
Reading/Writing versions using config file.

### DIFF
--- a/BraveHaxvius.sln
+++ b/BraveHaxvius.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csproj", "{512497B1-E79C-4DED-9B30-A9525F047B9B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BraveHaxvius", "BraveHaxvius\BraveHaxvius.csproj", "{BDCF492D-5BAD-43F0-9056-A24647CBE948}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IDAScripts", "IDAScripts", "{8F77CCB5-DF0D-485C-B2E5-88E726F9F094}"
@@ -17,8 +19,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PacketDecoder", "PacketDecoder\PacketDecoder.csproj", "{9B176963-698E-451F-821D-908620E17702}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testing", "Testing\Testing.csproj", "{9FB9B59B-47FE-4BB6-994D-2B3D12AEED48}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csproj", "{512497B1-E79C-4DED-9B30-A9525F047B9B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/BraveHaxvius/BraveExvius.cs
+++ b/BraveHaxvius/BraveExvius.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using BraveHaxvius.Data;
+using System.Configuration;
 
 namespace BraveHaxvius
 {
@@ -48,7 +49,26 @@ namespace BraveHaxvius
         public BraveExvius()
         {
             Network = new Networking { client = this };
+            
+            string readAppVersion = ConfigurationManager.AppSettings["AppVersion"];
+            if (readAppVersion.Length > 0)
+            {
+                AppVersion = readAppVersion;
+            }
+
+            string readRscVersion = ConfigurationManager.AppSettings["RscVersion"];
+            if (readRscVersion.Length > 0)
+            {
+                RscVersion = readRscVersion;
+            }
+
+            string readMstVersion = ConfigurationManager.AppSettings["MstVersion"];
+            if (readMstVersion.Length > 0)
+            {
+                MstVersion = readMstVersion;
+            }
         }
+        
         public JProperty UserInfo
         {
             get
@@ -106,6 +126,16 @@ namespace BraveHaxvius
         public List<String> GachaId { get; set; } = new List<String>();
         public List<String> GachaDetailId { get; set; } = new List<String>();
         public JObject GetUserInfo;
+        
+        public void UpdateConfig(string key, string value)
+        {
+            System.Configuration.Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            config.AppSettings.Settings[key].Value = value;
+
+            // Save the configuration file.
+            config.Save(ConfigurationSaveMode.Modified);
+        }
+        
         public void Login()
         {
             if (Locale != "JP" && FacebookUserId.Contains("@"))
@@ -1361,18 +1391,21 @@ namespace BraveHaxvius
                     AppVersion = (Initialize[GameObject.VersionInfo].First(f => f[Variable.KeyName].ToString().Contains("F_APP_VERSION")))[Variable.Value].ToString();
                     Initialize = Network.SendPacket(Request.Initialize);
                     Logger.Out("New AppVersion = " + AppVersion);
+                    UpdateConfig("AppVersion", AppVersion);                    
                 }
                 if (Initialize[GameObject.VersionInfo].Count(f => f[Variable.KeyName].ToString() == "F_MST_VERSION") > 0)
                 {
                     MstVersion = (Initialize[GameObject.VersionInfo].First(f => f[Variable.KeyName].ToString() == "F_MST_VERSION"))[Variable.Value].ToString();
                     Initialize = Network.SendPacket(Request.Initialize);
                     Logger.Out("New MstVersion = " + MstVersion);
+                    UpdateConfig("MstVersion", MstVersion);                    
                 }
                 if (Locale == "JP" && Initialize[GameObject.VersionInfo].Count(f => f[Variable.KeyName].ToString() == "F_RSC_VERSION") > 0)
                 {
                     RscVersion = (Initialize[GameObject.VersionInfo].First(f => f[Variable.KeyName].ToString() == "F_RSC_VERSION"))[Variable.Value].ToString();
                     Initialize = Network.SendPacket(Request.Initialize);
                     Logger.Out("New RscVersion = " + RscVersion);
+                    UpdateConfig("RscVersion", RscVersion);                    
                 }
             }
             if (String.IsNullOrEmpty(Initialize[GameObject.UserInfo][0][Variable.UserId].ToString()))

--- a/BraveHaxvius/BraveExvius.cs
+++ b/BraveHaxvius/BraveExvius.cs
@@ -1360,16 +1360,19 @@ namespace BraveHaxvius
                 {
                     AppVersion = (Initialize[GameObject.VersionInfo].First(f => f[Variable.KeyName].ToString().Contains("F_APP_VERSION")))[Variable.Value].ToString();
                     Initialize = Network.SendPacket(Request.Initialize);
+                    Logger.Out("New AppVersion = " + AppVersion);
                 }
                 if (Initialize[GameObject.VersionInfo].Count(f => f[Variable.KeyName].ToString() == "F_MST_VERSION") > 0)
                 {
                     MstVersion = (Initialize[GameObject.VersionInfo].First(f => f[Variable.KeyName].ToString() == "F_MST_VERSION"))[Variable.Value].ToString();
                     Initialize = Network.SendPacket(Request.Initialize);
+                    Logger.Out("New MstVersion = " + MstVersion);
                 }
                 if (Locale == "JP" && Initialize[GameObject.VersionInfo].Count(f => f[Variable.KeyName].ToString() == "F_RSC_VERSION") > 0)
                 {
                     RscVersion = (Initialize[GameObject.VersionInfo].First(f => f[Variable.KeyName].ToString() == "F_RSC_VERSION"))[Variable.Value].ToString();
                     Initialize = Network.SendPacket(Request.Initialize);
+                    Logger.Out("New RscVersion = " + RscVersion);
                 }
             }
             if (String.IsNullOrEmpty(Initialize[GameObject.UserInfo][0][Variable.UserId].ToString()))

--- a/BraveHaxvius/BraveHaxvius.csproj
+++ b/BraveHaxvius/BraveHaxvius.csproj
@@ -44,6 +44,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />    
     <Reference Include="System.Data" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />

--- a/BraveHaxvius/Networking.cs
+++ b/BraveHaxvius/Networking.cs
@@ -78,7 +78,7 @@ namespace BraveHaxvius
             var encryptedData = Crypto.Encrypt(decryptedDataString, request.EncodeKey);
             var packet = Packet(request.RequestID, encryptedData);
             var packetString = JsonConvert.SerializeObject(packet, Formatting.None);
-            var url = "https://lapisv230.gumi.sg/lapisProd/app/php/gme/actionSymbol/";
+            var url = "https://lapis-prod.gumi.sg/lapisProd/app/php/gme/actionSymbol/";
             //url = "https://lapis-dev.gumi.sg/lapisDev/app/php/gme/actionSymbol/";
             if (client.Locale == "JP")
                 url = "https://v29-android.game.exvius.com/lapis/app/php/gme/actionSymbol/";

--- a/Client/App.config
+++ b/Client/App.config
@@ -8,6 +8,12 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+    <appSettings>
+      <!-- Versions -->
+      <add key="AppVersion" value="1036" />
+      <add key="RscVersion" value="0" />
+      <add key="MstVersion" value="1155" />
+    </appSettings>    
     <userSettings>
         <Client.Properties.Settings>
             <setting name="fbidInput" serializeAs="String">

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -38,6 +38,7 @@
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Testing/App.config
+++ b/Testing/App.config
@@ -3,4 +3,10 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+    <appSettings>
+      <!-- Versions -->
+      <add key="AppVersion" value="1036" />
+      <add key="RscVersion" value="0" />
+      <add key="MstVersion" value="1155" />
+    </appSettings>    
 </configuration>


### PR DESCRIPTION
Reading version from config file in Client and Testing projects. If a new version is read on a packet, config file is updated. 

This updates the running apps config file, not app.config. Therefore building again, rather than running the executables, will overwrite the config file with the original app.config versions.

Also updated global's url in network.cs